### PR TITLE
Fix read errors on systems with line break conversion (Issue #1)

### DIFF
--- a/src/fileio.py
+++ b/src/fileio.py
@@ -147,12 +147,12 @@ class FileWriter(object):
 
 def write_midifile(midifile, pattern):
     if type(midifile) in (str, unicode):
-        midifile = open(midifile, 'w')
+        midifile = open(midifile, 'wb')
     writer = FileWriter()
     return writer.write(midifile, pattern)
 
 def read_midifile(midifile):
     if type(midifile) in (str, unicode):
-        midifile = open(midifile)
+        midifile = open(midifile, 'rb')
     reader = FileReader()
     return reader.read(midifile)


### PR DESCRIPTION
Updated fileio.py
This fixes "Bad track header in MIDI file" on systems with line break conversion (e.g. Windows)
