### PR TITLE
Tempo Calculation bug fix

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -1,4 +1,4 @@
-
+import pdb
 class EventRegistry(object):
     Events = {}
     MetaEvents = {}
@@ -75,7 +75,7 @@ class Event(AbstractEvent):
         if 'channel' not in kw:
             kw = kw.copy()
             kw['channel'] = 0
-            self.__kw = kw
+            #self.__kw = kw
         super(Event, self).__init__(**kw)
 
     def copy(self, **kw):


### PR DESCRIPTION
Modified a line that converts the three 8 bit mpqn fields to a 24bit number.  Calculation error present whenever any of the fields contained the same value due to the use of self.data.index() in the shift amount.
