### PR TITLE
Fixed bug where pitch wheel events were being masked incorrectly

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -202,8 +202,8 @@ class PitchWheelEvent(Event):
         return ((self.data[1] << 7) | self.data[0]) - 0x2000
     def set_pitch(self, pitch):
         value = pitch + 0x2000
-        self.data[0] = value & 0xFF
-        self.data[1] = (value >> 7) & 0xFF
+        self.data[0] = value & 0x7F
+        self.data[1] = (value >> 7) & 0x7F
     pitch = property(get_pitch, set_pitch)
 
 class SysexEvent(Event):


### PR DESCRIPTION
For example, if the variable pitch passed to PitchWheelEvent.set_pitch was 0x7FFF then data[0] would be set to 0x7FFF & 0xFF which is 0xFF.  This results in an event which has a data byte which is not 7-bit, which, for example, results in an invalid MIDI file when you write it out.
