### PR TITLE
Added MetaEvent 0x08.

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -264,6 +264,11 @@ class CuePointEvent(MetaEventWithText):
     metacommand = 0x07
     length = 'varlen'
 
+class ProgramNameEvent(MetaEventWithText):
+    name = 'Program Name'
+    metacommand = 0x08
+    length = 'varlen'
+
 class SomethingEvent(MetaEvent):
     name = 'Something'
     metacommand = 0x09


### PR DESCRIPTION
According to MIDI recommended practice 19, it is recommended to be used as "Program Name".
(http://www.midi.org/techspecs/rp19.php)
