### PR TITLE
Handle unknown MIDI meta events gracefully

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -10,9 +10,10 @@ class EventRegistry(object):
                             "Event %s already registered" % event.name
             cls.Events[event.statusmsg] = event
         elif (MetaEvent in bases) or (MetaEventWithText in bases):
-            assert event.metacommand not in cls.MetaEvents, \
-                            "Event %s already registered" % event.name
-            cls.MetaEvents[event.metacommand] = event
+            if event.metacommand is not None:
+                assert event.metacommand not in cls.MetaEvents, \
+                                "Event %s already registered" % event.name
+                cls.MetaEvents[event.metacommand] = event
         else:
             raise ValueError, "Unknown bases class in event type: "+event.name
     register_event = classmethod(register_event)
@@ -269,9 +270,19 @@ class ProgramNameEvent(MetaEventWithText):
     metacommand = 0x08
     length = 'varlen'
 
-class SomethingEvent(MetaEvent):
-    name = 'Something'
-    metacommand = 0x09
+class UnknownMetaEvent(MetaEvent):
+    name = 'Unknown'
+    # This class variable must be overriden by code calling the constructor,
+    # which sets a local variable of the same name to shadow the class variable.
+    metacommand = None
+
+    def __init__(self, **kw):
+        super(MetaEvent, self).__init__(**kw)
+        self.metacommand = kw['metacommand']
+
+    def copy(self, **kw):
+        kw['metacommand'] = self.metacommand
+        return super(UnknownMetaEvent, self).copy(kw)
 
 class ChannelPrefixEvent(MetaEvent):
     name = 'Channel Prefix'

--- a/src/fileio.py
+++ b/src/fileio.py
@@ -1,3 +1,5 @@
+from warnings import *
+
 from containers import *
 from events import *
 from struct import unpack, pack
@@ -61,11 +63,13 @@ class FileReader(object):
         if MetaEvent.is_event(stsmsg):
             cmd = ord(trackdata.next())
             if cmd not in EventRegistry.MetaEvents:
-                raise Warning, "Unknown Meta MIDI Event: " + `cmd`
-            cls = EventRegistry.MetaEvents[cmd]
+                warn("Unknown Meta MIDI Event: " + `cmd`, Warning)
+                cls = UnknownMetaEvent
+            else:
+                cls = EventRegistry.MetaEvents[cmd]
             datalen = read_varlen(trackdata)
             data = [ord(trackdata.next()) for x in range(datalen)]
-            return cls(tick=tick, data=data)
+            return cls(tick=tick, data=data, metacommand=cmd)
         # is this event a Sysex Event?
         elif SysexEvent.is_event(stsmsg):
             data = []


### PR DESCRIPTION
Instead of throwing an error, this makes the library display a warning to the
user (which can be suppressed if desired), and inserts an UnknownMetaEvent into
the track at the appropriate location. This doesn't break any existing code that worked with UnknownMidiEvent objects (for meta event 0x09), but it does prevent the library from crashing when it receives other unknown midi events.