### PR TITLE
add a class to convert from absolute MIDI tick to milliseconds

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -158,6 +158,23 @@ pattern = midi.read_midifile("example.mid")
 print pattern
 </pre>
 
+If you want to convert from midi ticks to milliseconds, you can use the TimeResolver
+wrapper class:
+
+<pre>
+import midi
+import midi.sequencer as sequencer
+pattern = midi.read_midifile("example.mid")
+pattern.make_ticks_abs()
+time_resolver = sequencer.TimeResolver(pattern)
+for track in pattern:
+    for event in track:
+        name = event.name
+        tick = event.tick
+        milliseconds = time_resolver.tick2ms(tick)
+        print ("event {0} with MIDI tick {1} happens after {2} milliseconds.".format(name, tick, milliseconds))
+</pre>
+
 ==Sequencer==
 
 If you use this toolkit under Linux, you can take advantage of ALSA's

--- a/examples/example_3.py
+++ b/examples/example_3.py
@@ -1,0 +1,12 @@
+import midi
+import midi.sequencer as sequencer
+
+pattern = midi.read_file("mary.mid")
+pattern.make_ticks_abs()
+timeresolver = sequencer.TimeResolver(pattern)
+for track in pattern:
+    for event in track:
+        tick = event.tick
+        milliseconds = timeresolver.tick2ms(tick)
+        print ("event {2} at tick {0} happens {1} ms after starting the piece".format(tick, milliseconds, event.name))
+


### PR DESCRIPTION
same as before, but now on the python3 branch

it seems to work for me, maybe it's also interesting for you

I've implemented it as a wrapper class to avoid messing up the existing code base and to avoid making the system slower if this functionality is not needed.

