### PR TITLE
Eliminate corruption when writing MIDIs due to RunningStatus

### DIFF
--- a/src/fileio.py
+++ b/src/fileio.py
@@ -132,11 +132,13 @@ class FileWriter(object):
             ret += chr(event.statusmsg) + chr(event.metacommand)
             ret += write_varlen(len(event.data))
             ret += str.join('', map(chr, event.data))
+            self.RunningStatus = None
         # is this event a Sysex Event?
         elif isinstance(event, SysexEvent):
             ret += chr(0xF0)
             ret += str.join('', map(chr, event.data))
             ret += chr(0xF7)
+            self.RunningStatus = None
         # not a Meta MIDI event or a Sysex event, must be a general message
         elif isinstance(event, Event):
             if not self.RunningStatus or \


### PR DESCRIPTION
When writing midis, a running state is used so that if multiple messages of the same type are used in a row, the message type only has to be specified once. This is fine, except for the fact that MetaEvents and SysexEvents does not cause the state to reset. This can cause the generated midis to be unreadable by some (but not all) software, so here's a quick fix.
