### PR TITLE
Python 3 compatibility

### DIFF
--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import midi
 # Instantiate a MIDI Pattern (contains a list of tracks)
 pattern = midi.Pattern()
@@ -15,6 +16,6 @@ track.append(off)
 eot = midi.EndOfTrackEvent(tick=1)
 track.append(eot)
 # Print out the pattern
-print pattern
+print(pattern)
 # Save the pattern to disk
 midi.write_midifile("example.mid", pattern)

--- a/examples/example_2.py
+++ b/examples/example_2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import midi
 pattern = midi.read_midifile("example.mid")
-print pattern
+print(pattern)

--- a/scripts/mididump.py
+++ b/scripts/mididump.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 """
 Print a description of a MIDI file.
 """
@@ -6,9 +8,9 @@ import midi
 import sys
 
 if len(sys.argv) != 2:
-    print "Usage: {0} <midifile>".format(sys.argv[0])
+    print("Usage: {0} <midifile>".format(sys.argv[0]))
     sys.exit(2)
 
 midifile = sys.argv[1]
 pattern = midi.read_midifile(midifile)
-print repr(pattern)
+print(repr(pattern))

--- a/scripts/mididumphw.py
+++ b/scripts/mididumphw.py
@@ -2,8 +2,9 @@
 """
 Print a description of the available devices.
 """
+from __future__ import print_function
 import midi.sequencer as sequencer
 
 s = sequencer.SequencerHardware()
 
-print s
+print(s)

--- a/scripts/midilisten.py
+++ b/scripts/midilisten.py
@@ -2,13 +2,15 @@
 """
 Attach to a MIDI device and print events to standard output.
 """
+from __future__ import print_function
+
 import sys
 import time
 import midi
 import midi.sequencer as sequencer
 
 if len(sys.argv) != 3:
-    print "Usage: {0} <client> <port>".format(sys.argv[0])
+    print("Usage: {0} <client> <port>".format(sys.argv[0]))
     exit(2)
 
 client = sys.argv[1]
@@ -21,4 +23,4 @@ seq.start_sequencer()
 while True:
   event = seq.event_read()
   if event is not None:
-      print event
+      print(event)

--- a/scripts/midiplay.py
+++ b/scripts/midiplay.py
@@ -2,13 +2,15 @@
 """
 Attach to a MIDI device and send the contents of a MIDI file to it.
 """
+from __future__ import print_function
+
 import sys
 import time
 import midi
 import midi.sequencer as sequencer
 
 if len(sys.argv) != 4:
-    print "Usage: {0} <client> <port> <file>".format(sys.argv[0])
+    print("Usage: {0} <client> <port> <file>".format(sys.argv[0]))
     exit(2)
 
 client   = sys.argv[1]
@@ -45,4 +47,4 @@ while event.tick > seq.queue_get_tick_time():
     seq.drain()
     time.sleep(.5)
 
-print 'The end?'
+print('The end?')

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,14 @@ __base__ = {
     'ext_modules':[],
     'ext_package':'',
     'scripts':['scripts/mididump.py', 'scripts/mididumphw.py', 'scripts/midiplay.py'],
+    'install_requires':['future'],
 }
 
 # this kludge ensures we run the build_ext first before anything else
 # otherwise, we will be missing generated files during the copy
 class Install_Command_build_ext_first(setuptools.command.install.install):
     def run(self):
+        setuptools.command.install.install.do_egg_install(self)
         self.run_command("build_ext")
         return setuptools.command.install.install.run(self)
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
 from setuptools import setup, Extension
 import setuptools.command.install
@@ -62,7 +63,7 @@ def configure_platform():
         setup_alsa(ns)
         pass
     else:
-        print "No sequencer available for '%s' platform." % platform
+        print("No sequencer available for '%s' platform." % platform)
     return ns
 
 if __name__ == "__main__":

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,6 @@
-from containers import *
-from events import *
 from struct import unpack, pack
-from util import *
-from fileio import *
+
+from .containers import *
+from .events import *
+from .util import *
+from .fileio import *

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,13 +3,13 @@
 ##
 
 OCTAVE_MAX_VALUE = 12
-OCTAVE_VALUES = range( OCTAVE_MAX_VALUE )
+OCTAVE_VALUES = list(range( OCTAVE_MAX_VALUE))
 
-NOTE_NAMES = ['C','Cs','D','Ds','E','F','Fs','G','Gs','A','As','B']
+NOTE_NAMES = ['C', 'Cs', 'D', 'Ds', 'E', 'F', 'Fs', 'G', 'Gs', 'A', 'As', 'B']
 WHITE_KEYS = [0, 2, 4, 5, 7, 9, 11]
 BLACK_KEYS = [1, 3, 6, 8, 10]
 NOTE_PER_OCTAVE = len( NOTE_NAMES )
-NOTE_VALUES = range( OCTAVE_MAX_VALUE * NOTE_PER_OCTAVE )
+NOTE_VALUES = list(range( OCTAVE_MAX_VALUE * NOTE_PER_OCTAVE))
 NOTE_NAME_MAP_FLAT = {}
 NOTE_VALUE_MAP_FLAT = []
 NOTE_NAME_MAP_SHARP = {}

--- a/src/containers.py
+++ b/src/containers.py
@@ -25,7 +25,7 @@ class Pattern(list):
         if isinstance(item, slice):
             indices = item.indices(len(self))
             return Pattern(resolution=self.resolution, format=self.format,
-                            tracks=(super(Pattern, self).__getitem__(i) for i in xrange(*indices)))
+                            tracks=(super(Pattern, self).__getitem__(i) for i in range(*indices)))
         else:
             return super(Pattern, self).__getitem__(item)
 
@@ -58,7 +58,7 @@ class Track(list):
     def __getitem__(self, item):
         if isinstance(item, slice):
             indices = item.indices(len(self))
-            return Track((super(Track, self).__getitem__(i) for i in xrange(*indices)))
+            return Track((super(Track, self).__getitem__(i) for i in range(*indices)))
         else:
             return super(Track, self).__getitem__(item)
 

--- a/src/events.py
+++ b/src/events.py
@@ -1,4 +1,5 @@
 import math
+from future.utils import with_metaclass
 
 class EventRegistry(object):
     Events = {}
@@ -19,17 +20,18 @@ class EventRegistry(object):
     register_event = classmethod(register_event)
 
 
-class AbstractEvent(object):
+class RegisterEventMeta(type):
+    def __init__(cls, name, bases, dict):
+        if name not in ['AbstractEvent', 'Event', 'MetaEvent', 'NoteEvent',
+                        'MetaEventWithText']:
+            EventRegistry.register_event(cls, bases)
+
+class AbstractEvent(with_metaclass(RegisterEventMeta,object)):
     __slots__ = ['tick', 'data']
     name = "Generic MIDI Event"
     length = 0
     statusmsg = 0x0
 
-    class __metaclass__(type):
-        def __init__(cls, name, bases, dict):
-            if name not in ['AbstractEvent', 'Event', 'MetaEvent', 'NoteEvent',
-                            'MetaEventWithText']:
-                EventRegistry.register_event(cls, bases)
 
     def __init__(self, **kw):
         if type(self.length) == int:

--- a/src/events.py
+++ b/src/events.py
@@ -111,7 +111,6 @@ and NoteOff events.
 """
 
 class NoteEvent(Event):
-    __slots__ = ['pitch', 'velocity']
     length = 2
 
     def get_pitch(self):
@@ -152,7 +151,6 @@ class AfterTouchEvent(Event):
     value = property(get_value, set_value)
 
 class ControlChangeEvent(Event):
-    __slots__ = ['control', 'value']
     statusmsg = 0xB0
     length = 2
     name = 'Control Change'
@@ -170,7 +168,6 @@ class ControlChangeEvent(Event):
     value = property(get_value, set_value)
 
 class ProgramChangeEvent(Event):
-    __slots__ = ['value']
     statusmsg = 0xC0
     length = 1
     name = 'Program Change'
@@ -182,7 +179,6 @@ class ProgramChangeEvent(Event):
     value = property(get_value, set_value)
 
 class ChannelAfterTouchEvent(Event):
-    __slots__ = ['value']
     statusmsg = 0xD0
     length = 1
     name = 'Channel After Touch'
@@ -194,7 +190,6 @@ class ChannelAfterTouchEvent(Event):
     value = property(get_value, set_value)
 
 class PitchWheelEvent(Event):
-    __slots__ = ['pitch']
     statusmsg = 0xE0
     length = 2
     name = 'Pitch Wheel'
@@ -302,7 +297,6 @@ class EndOfTrackEvent(MetaEvent):
     metacommand = 0x2F
 
 class SetTempoEvent(MetaEvent):
-    __slots__ = ['bpm', 'mpqn']
     name = 'Set Tempo'
     metacommand = 0x51
     length = 3
@@ -315,7 +309,7 @@ class SetTempoEvent(MetaEvent):
 
     def get_mpqn(self):
         assert(len(self.data) == 3)
-        vals = [self.data[x] << (16 - (8 * x)) for x in xrange(3)]
+        vals = [self.data[x] << (16 - (8 * x)) for x in range(3)]
         return sum(vals)
     def set_mpqn(self, val):
         self.data = [(val >> (16 - (8 * x)) & 0xFF) for x in range(3)]
@@ -326,7 +320,6 @@ class SmpteOffsetEvent(MetaEvent):
     metacommand = 0x54
 
 class TimeSignatureEvent(MetaEvent):
-    __slots__ = ['numerator', 'denominator', 'metronome', 'thirtyseconds']
     name = 'Time Signature'
     metacommand = 0x58
     length = 4
@@ -356,7 +349,6 @@ class TimeSignatureEvent(MetaEvent):
     thirtyseconds = property(get_thirtyseconds, set_thirtyseconds)
 
 class KeySignatureEvent(MetaEvent):
-    __slots__ = ['alternatives', 'minor']
     name = 'Key Signature'
     metacommand = 0x59
     length = 2

--- a/src/events.py
+++ b/src/events.py
@@ -16,7 +16,7 @@ class EventRegistry(object):
                                 "Event %s already registered" % event.name
                 cls.MetaEvents[event.metacommand] = event
         else:
-            raise ValueError, "Unknown bases class in event type: "+event.name
+            raise ValueError("Unknown bases class in event type: ", event.name)
     register_event = classmethod(register_event)
 
 

--- a/src/events.py
+++ b/src/events.py
@@ -43,10 +43,18 @@ class AbstractEvent(with_metaclass(RegisterEventMeta,object)):
         for key in kw:
             setattr(self, key, kw[key])
 
-    def __cmp__(self, other):
-        if self.tick < other.tick: return -1
-        elif self.tick > other.tick: return 1
-        return cmp(self.data, other.data)
+    def __lt__(self, other):
+        if self.tick < other.tick:
+            return True
+        return self.data < other.data
+
+    def __eq__(self, other):
+        return (self.__class__ is other.__class__ and
+                self.tick == other.tick and
+                self.data == other.data)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __baserepr__(self, keys=[]):
         keys = ['tick'] + keys + ['data']
@@ -77,10 +85,14 @@ class Event(AbstractEvent):
         _kw.update(kw)
         return self.__class__(**_kw)
 
-    def __cmp__(self, other):
-        if self.tick < other.tick: return -1
-        elif self.tick > other.tick: return 1
-        return 0
+    def __lt__(self, other):
+        return (super(Event, self).__lt__(other) or
+                (super(Event, self).__eq__(other) and
+                 self.channel < other.channel))
+
+    def __eq__(self, other):
+        return super(Event, self).__eq__(other) and \
+            self.channel == other.channel
 
     def __repr__(self):
         return self.__baserepr__(['channel'])

--- a/src/fileio.py
+++ b/src/fileio.py
@@ -18,7 +18,7 @@ class FileReader(object):
         # First four bytes are MIDI header
         magic = midifile.read(4)
         if magic != 'MThd':
-            raise TypeError, "Bad header in MIDI file."
+            raise TypeError("Bad header in MIDI file.")
         # next four bytes are header size
         # next two bytes specify the format version
         # next two bytes specify the number of tracks
@@ -39,7 +39,7 @@ class FileReader(object):
         # First four bytes are Track header
         magic = midifile.read(4)
         if magic != 'MTrk':
-            raise TypeError, "Bad track header in MIDI file: " + magic
+            raise TypeError("Bad track header in MIDI file: " + magic)
         # next four bytes are track size
         trksz = unpack(">L", midifile.read(4))[0]
         return trksz
@@ -64,7 +64,7 @@ class FileReader(object):
         if MetaEvent.is_event(stsmsg):
             cmd = ord(trackdata.next())
             if cmd not in EventRegistry.MetaEvents:
-                warn("Unknown Meta MIDI Event: " + `cmd`, Warning)
+                warn("Unknown Meta MIDI Event: " + repr(cmd), Warning)
                 cls = UnknownMetaEvent
             else:
                 cls = EventRegistry.MetaEvents[cmd]
@@ -98,7 +98,7 @@ class FileReader(object):
                 channel = self.RunningStatus & 0x0F
                 data = [ord(trackdata.next()) for x in range(cls.length)]
                 return cls(tick=tick, channel=channel, data=data)
-        raise Warning, "Unknown MIDI Event: " + `stsmsg`
+        raise Warning("Unknown MIDI Event: " + repr(stsmsg))
 
 class FileWriter(object):
     def write(self, midifile, pattern):
@@ -147,7 +147,7 @@ class FileWriter(object):
                     ret += chr(event.statusmsg | event.channel)
             ret += str.join('', map(chr, event.data))
         else:
-            raise ValueError, "Unknown MIDI Event: " + str(event)
+            raise ValueError("Unknown MIDI Event: " + str(event))
         return ret
 
 def write_midifile(midifile, pattern):

--- a/src/fileio.py
+++ b/src/fileio.py
@@ -1,10 +1,11 @@
 from warnings import *
 
-from containers import *
-from events import *
 from struct import unpack, pack
-from constants import *
-from util import *
+
+from .containers import *
+from .events import *
+from .constants import *
+from .util import *
 
 class FileReader(object):
     def read(self, midifile):

--- a/src/sequencer.py
+++ b/src/sequencer.py
@@ -50,9 +50,9 @@ class EventStreamIterator(object):
         self.ttpts.append(stream.endoftrack.tick)
         self.ttpts = iter(self.ttpts)
         # Setup next tempo timepoint
-        self.ttp = self.ttpts.next()
+        self.ttp = next(self.ttpts)
         self.tempomap = iter(self.stream.tempomap)
-        self.tempo = self.tempomap.next()
+        self.tempo = next(self.tempomap)
         self.endoftrack = False
 
     def __iter__(self):
@@ -67,7 +67,7 @@ class EventStreamIterator(object):
             # We're past the tempo-marker.
             oldttp = self.ttp
             try:
-                self.ttp = self.ttpts.next()
+                self.ttp = next(self.ttpts)
             except StopIteration:
                 # End of Track!
                 self.window_edge = self.ttp
@@ -77,11 +77,11 @@ class EventStreamIterator(object):
             # account the tempo change.
             msused = (oldttp - lastedge) * self.tempo.mpt
             msleft = self.window_length - msused
-            self.tempo = self.tempomap.next()
+            self.tempo = next(self.tempomap)
             ticksleft = msleft / self.tempo.mpt
             self.window_edge = ticksleft + self.tempo.tick
 
-    def next(self):
+    def __next__(self):
         ret = []
         self.__next_edge()
         if self.leftover:

--- a/src/sequencer_alsa/sequencer.py
+++ b/src/sequencer_alsa/sequencer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import select
 import sequencer_alsa as S
 import midi
@@ -204,7 +205,7 @@ class Sequencer(object):
     ## EVENT HANDLERS
     ##
     def event_write(self, event, direct=False, relative=False, tick=False):
-        #print event.__class__, event
+        #print(event.__class__, event)
         ## Event Filter
         if isinstance(event, midi.EndOfTrackEvent):
             return
@@ -269,7 +270,7 @@ class Sequencer(object):
             seqev.data.control.value = event.pitch
         ## Unknown
         else:
-            print "Warning :: Unknown event type: %s" % event
+            print("Warning :: Unknown event type: %s" % event)
             return None
             
         err = S.snd_seq_event_output(self.client, seqev)

--- a/src/sequencer_osx/test.py
+++ b/src/sequencer_osx/test.py
@@ -1,9 +1,11 @@
+from __future__ import print_function
 import sequencer_osx
-print "MIDIGetNumberOfDevices:", sequencer_osx._MIDIGetNumberOfDevices()
+
+print("MIDIGetNumberOfDevices:", sequencer_osx._MIDIGetNumberOfDevices())
 client = sequencer_osx._MIDIClientCreate("python")
 endpoint = sequencer_osx._MIDISourceCreate(client, "python-source")
 port = sequencer_osx._MIDIOutputPortCreate(client, "python-port")
 sequencer_osx._MIDIPortConnectSource(port, endpoint)
-print client, endpoint, endpoint
+print(client, endpoint, endpoint)
 raw_input()
 #sequencer_osx._MIDIClientDispose(handle)

--- a/src/util.py
+++ b/src/util.py
@@ -3,7 +3,7 @@ def read_varlen(data):
     NEXTBYTE = 1
     value = 0
     while NEXTBYTE:
-        chr = ord(data.next())
+        chr = next(data)
         # is the hi-bit set?
         if not (chr & 0x80):
             # no next BYTE

--- a/src/util.py
+++ b/src/util.py
@@ -17,22 +17,9 @@ def read_varlen(data):
     return value
 
 def write_varlen(value):
-    chr1 = chr(value & 0x7F)
-    value >>= 7
-    if value:
-        chr2 = chr((value & 0x7F) | 0x80)
+    result = bytearray()
+    while value > 0x7F:
+        result.append((value & 0x7F) | 0x80)
         value >>= 7
-        if value:
-            chr3 = chr((value & 0x7F) | 0x80)
-            value >>= 7
-            if value:
-                chr4 = chr((value & 0x7F) | 0x80)
-                res = chr4 + chr3 + chr2 + chr1
-            else:
-                res = chr3 + chr2 + chr1
-        else:
-            res = chr2 + chr1
-    else:
-        res = chr1
-    return res
-
+    result.append(value)
+    return result


### PR DESCRIPTION
As promised in #35 here a set of patches that make the master branch (more) compatible with Python 3. As I am not using the sequencer there may still be issues with Python3 left. In general the changes are supposed to keep the code working with Python >=2.6 while also making it run with Python 3.

This patch set does *not* port all changes that have been made to the features/Python3 branch.
This patch set breaks the compatibility of the functions in src/util.py basically assuming they are private.