### PR TITLE
Octave index calculation should use notes per octave

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -17,7 +17,7 @@ NOTE_VALUE_MAP_SHARP = []
 
 for value in range( 128 ):
     noteidx = value % NOTE_PER_OCTAVE
-    octidx = value / OCTAVE_MAX_VALUE
+    octidx = value / NOTE_PER_OCTAVE
     name = NOTE_NAMES[noteidx]
     if len( name ) == 2:
         # sharp note
@@ -46,4 +46,3 @@ THIRTYSECOND = 5
 SIXTYFOURTH = 6
 
 DEFAULT_MIDI_HEADER_SIZE = 14
-


### PR DESCRIPTION
By accident OCTAVE_MAX_VALUE and NOTES_PER_OCTAVE match, but if I understand it correctly the first should be used here.