### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import midi
 # Instantiate a MIDI Pattern (contains a list of tracks)
 pattern = midi.Pattern()
@@ -15,6 +16,6 @@ track.append(off)
 eot = midi.EndOfTrackEvent(tick=1)
 track.append(eot)
 # Print out the pattern
-print pattern
+print(pattern)
 # Save the pattern to disk
 midi.write_midifile("example.mid", pattern)

--- a/examples/example_2.py
+++ b/examples/example_2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import midi
 pattern = midi.read_midifile("example.mid")
-print pattern
+print(pattern)

--- a/scripts/mididump.py
+++ b/scripts/mididump.py
@@ -2,13 +2,14 @@
 """
 Print a description of a MIDI file.
 """
+from __future__ import print_function
 import midi
 import sys
 
 if len(sys.argv) != 2:
-    print "Usage: {0} <midifile>".format(sys.argv[0])
+    print("Usage: {0} <midifile>".format(sys.argv[0]))
     sys.exit(2)
 
 midifile = sys.argv[1]
 pattern = midi.read_midifile(midifile)
-print repr(pattern)
+print(repr(pattern))

--- a/scripts/mididumphw.py
+++ b/scripts/mididumphw.py
@@ -2,8 +2,9 @@
 """
 Print a description of the available devices.
 """
+from __future__ import print_function
 import midi.sequencer as sequencer
 
 s = sequencer.SequencerHardware()
 
-print s
+print(s)

--- a/scripts/midilisten.py
+++ b/scripts/midilisten.py
@@ -2,13 +2,14 @@
 """
 Attach to a MIDI device and print events to standard output.
 """
+from __future__ import print_function
 import sys
 import time
 import midi
 import midi.sequencer as sequencer
 
 if len(sys.argv) != 3:
-    print "Usage: {0} <client> <port>".format(sys.argv[0])
+    print("Usage: {0} <client> <port>".format(sys.argv[0]))
     exit(2)
 
 client = sys.argv[1]
@@ -21,4 +22,4 @@ seq.start_sequencer()
 while True:
   event = seq.event_read()
   if event is not None:
-      print event
+      print(event)

--- a/scripts/midiplay.py
+++ b/scripts/midiplay.py
@@ -2,13 +2,14 @@
 """
 Attach to a MIDI device and send the contents of a MIDI file to it.
 """
+from __future__ import print_function
 import sys
 import time
 import midi
 import midi.sequencer as sequencer
 
 if len(sys.argv) != 4:
-    print "Usage: {0} <client> <port> <file>".format(sys.argv[0])
+    print("Usage: {0} <client> <port> <file>".format(sys.argv[0]))
     exit(2)
 
 client   = sys.argv[1]
@@ -45,4 +46,4 @@ while event.tick > seq.queue_get_tick_time():
     seq.drain()
     time.sleep(.5)
 
-print 'The end?'
+print('The end?')

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
 from setuptools import setup, Extension
 import setuptools.command.install
@@ -60,12 +61,10 @@ def configure_platform():
     # currently, only the ALSA sequencer is supported
     if platform.startswith('linux'):
         setup_alsa(ns)
-        pass
     else:
-        print "No sequencer available for '%s' platform." % platform
+        print("No sequencer available for '%s' platform." % platform)
     return ns
 
 if __name__ == "__main__":
     setup(**configure_platform())
-
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,6 @@
-from containers import *
-from events import *
+from __future__ import absolute_import
+from .containers import *
+from .events import *
 from struct import unpack, pack
-from util import *
-from fileio import *
+from .util import *
+from .fileio import *

--- a/src/containers.py
+++ b/src/containers.py
@@ -1,5 +1,11 @@
 from pprint import pformat, pprint
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 class Pattern(list):
     def __init__(self, tracks=[], resolution=220, format=1, tick_relative=True):
         self.format = format

--- a/src/events.py
+++ b/src/events.py
@@ -1,5 +1,11 @@
 import math
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 class EventRegistry(object):
     Events = {}
     MetaEvents = {}
@@ -15,7 +21,7 @@ class EventRegistry(object):
                                 "Event %s already registered" % event.name
                 cls.MetaEvents[event.metacommand] = event
         else:
-            raise ValueError, "Unknown bases class in event type: "+event.name
+            raise ValueError("Unknown bases class in event type: "+event.name)
     register_event = classmethod(register_event)
 
 
@@ -138,13 +144,13 @@ class AfterTouchEvent(Event):
     statusmsg = 0xA0
     length = 2
     name = 'After Touch'
-    
+
     def get_pitch(self):
         return self.data[0]
     def set_pitch(self, val):
         self.data[0] = val
     pitch = property(get_pitch, set_pitch)
-    
+
     def get_value(self):
         return self.data[1]
     def set_value(self, val):
@@ -226,7 +232,7 @@ class MetaEventWithText(MetaEvent):
         super(MetaEventWithText, self).__init__(**kw)
         if 'text' not in kw:
             self.text = ''.join(chr(datum) for datum in self.data)
-    
+
     def __repr__(self):
         return self.__baserepr__(['text'])
 

--- a/src/sequencer.py
+++ b/src/sequencer.py
@@ -50,9 +50,9 @@ class EventStreamIterator(object):
         self.ttpts.append(stream.endoftrack.tick)
         self.ttpts = iter(self.ttpts)
         # Setup next tempo timepoint
-        self.ttp = self.ttpts.next()
+        self.ttp = next(self.ttpts)
         self.tempomap = iter(self.stream.tempomap)
-        self.tempo = self.tempomap.next()
+        self.tempo = next(self.tempomap)
         self.endoftrack = False
 
     def __iter__(self):
@@ -67,7 +67,7 @@ class EventStreamIterator(object):
             # We're past the tempo-marker.
             oldttp = self.ttp
             try:
-                self.ttp = self.ttpts.next()
+                self.ttp = next(self.ttpts)
             except StopIteration:
                 # End of Track!
                 self.window_edge = self.ttp
@@ -77,7 +77,7 @@ class EventStreamIterator(object):
             # account the tempo change.
             msused = (oldttp - lastedge) * self.tempo.mpt
             msleft = self.window_length - msused
-            self.tempo = self.tempomap.next()
+            self.tempo = next(self.tempomap)
             ticksleft = msleft / self.tempo.mpt
             self.window_edge = ticksleft + self.tempo.tick
 

--- a/src/sequencer_alsa/__init__.py
+++ b/src/sequencer_alsa/__init__.py
@@ -1,4 +1,5 @@
+from __future__ import absolute_import
 try:
-    from sequencer import *
+    from .sequencer import *
 except ImportError:
     pass

--- a/src/sequencer_alsa/sequencer.py
+++ b/src/sequencer_alsa/sequencer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import select
 import sequencer_alsa as S
 import midi
@@ -72,7 +73,7 @@ class Sequencer(object):
     def _error(self, errcode):
         strerr = S.snd_strerror(errcode)
         msg = "ALSAError[%d]: %s" % (errcode, strerr)
-        raise RuntimeError, msg
+        raise RuntimeError(msg)
 
     def _init_handle(self):
         ret = S.open_client(self.alsa_sequencer_name,
@@ -90,8 +91,8 @@ class Sequencer(object):
 
     def _init_port(self):
         err = S.snd_seq_create_simple_port(self.client,
-                                            self.alsa_port_name, 
-                                            self.alsa_port_caps, 
+                                            self.alsa_port_name,
+                                            self.alsa_port_caps,
                                             self.alsa_port_type)
         if err < 0: self._error(err)
         self.port = err
@@ -126,13 +127,13 @@ class Sequencer(object):
         addr.client = int(client)
         addr.port = int(port)
         return addr
-    
+
     def _init_queue(self):
         err = S.snd_seq_alloc_named_queue(self.client, self.alsa_queue_name)
         if err < 0: self._error(err)
         self.queue = err
         adjtempo = int(60.0 * 1000000.0 / self.sequencer_tempo)
-        S.init_queue_tempo(self.client, self.queue, 
+        S.init_queue_tempo(self.client, self.queue,
                             adjtempo, self.sequencer_resolution)
 
     def _control_queue(self, ctype, cvalue, event=None):
@@ -180,7 +181,7 @@ class Sequencer(object):
         if self._queue_running:
             self._control_queue(S.SND_SEQ_EVENT_STOP, 0, event)
             self._queue_running = False
-    
+
     def drain(self):
         S.snd_seq_drain_output(self.client)
 
@@ -269,9 +270,9 @@ class Sequencer(object):
             seqev.data.control.value = event.pitch
         ## Unknown
         else:
-            print "Warning :: Unknown event type: %s" % event
+            print("Warning :: Unknown event type: %s" % event)
             return None
-            
+
         err = S.snd_seq_event_output(self.client, seqev)
         if (err < 0): self._error(err)
         self.drain()
@@ -332,7 +333,7 @@ class SequencerHardware(Sequencer):
         def get_port(self, key):
             return self._ports[key]
         __getitem__ = get_port
-        
+
         class Port(object):
             def __init__(self, port, name, caps):
                 self.port = port
@@ -451,4 +452,3 @@ class SequencerDuplex(Sequencer):
         dest = self._new_address(client, port)
         subscribe = self._new_subscribe(sender, dest, read=False)
         self._subscribe_port(subscribe)
-

--- a/src/sequencer_osx/sequencer_osx.py
+++ b/src/sequencer_osx/sequencer_osx.py
@@ -31,7 +31,7 @@ def _swig_getattr(self,class_type,name):
     if (name == "thisown"): return self.this.own()
     method = class_type.__swig_getmethods__.get(name,None)
     if method: return method(self)
-    raise AttributeError,name
+    raise AttributeError(name)
 
 def _swig_repr(self):
     try: strthis = "proxy of " + self.this.__repr__()
@@ -40,7 +40,7 @@ def _swig_repr(self):
 
 import types
 try:
-    _object = types.ObjectType
+    _object = object
     _newclass = 1
 except AttributeError:
     class _object : pass

--- a/src/sequencer_osx/test.py
+++ b/src/sequencer_osx/test.py
@@ -1,9 +1,17 @@
+from __future__ import print_function
+
 import sequencer_osx
-print "MIDIGetNumberOfDevices:", sequencer_osx._MIDIGetNumberOfDevices()
+
+print("MIDIGetNumberOfDevices:", sequencer_osx._MIDIGetNumberOfDevices())
 client = sequencer_osx._MIDIClientCreate("python")
 endpoint = sequencer_osx._MIDISourceCreate(client, "python-source")
 port = sequencer_osx._MIDIOutputPortCreate(client, "python-port")
 sequencer_osx._MIDIPortConnectSource(port, endpoint)
-print client, endpoint, endpoint
-raw_input()
-#sequencer_osx._MIDIClientDispose(handle)
+print(client, endpoint, endpoint)
+
+try:
+    raw_input()  # Python 2
+except NameError:
+    input()     # Python 3
+
+# sequencer_osx._MIDIClientDispose(handle)

--- a/src/util.py
+++ b/src/util.py
@@ -3,7 +3,7 @@ def read_varlen(data):
     NEXTBYTE = 1
     value = 0
     while NEXTBYTE:
-        chr = ord(data.next())
+        chr = ord(next(data))
         # is the hi-bit set?
         if not (chr & 0x80):
             # no next BYTE

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,20 +9,26 @@ try:
 except ImportError:
     sequencer = None
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 def get_sequencer_type():
     if sequencer == None:
         return None
     return sequencer.Sequencer.SEQUENCER_TYPE
 
 class TestMIDI(unittest.TestCase):
-    def test_varlen(self): 
+    def test_varlen(self):
         maxval = 0x0FFFFFFF
         for inval in xrange(0, maxval, maxval / 1000):
             datum = midi.write_varlen(inval)
             outval = midi.read_varlen(iter(datum))
             self.assertEqual(inval, outval)
 
-    def test_mary(self): 
+    def test_mary(self):
         midi.write_midifile("mary.mid", mary_test.MARY_MIDI)
         pattern1 = midi.read_midifile("mary.mid")
         midi.write_midifile("mary.mid", pattern1)
@@ -47,7 +53,7 @@ class TestSequencerALSA(unittest.TestCase):
         assert loop != None, "Could not find Midi Through port!"
         loop_port = loop.get_port("Midi Through Port-0")
         return (loop.client, loop_port.port)
-    
+
     def get_reader_sequencer(self):
         (client, port) = self.get_loop_client_port()
         seq = sequencer.SequencerRead(sequencer_resolution=self.RESOLUTION)
@@ -59,7 +65,7 @@ class TestSequencerALSA(unittest.TestCase):
         seq = sequencer.SequencerWrite(sequencer_resolution=self.RESOLUTION)
         seq.subscribe_port(client, port)
         return seq
-    
+
     @unittest.skipIf(get_sequencer_type() != "alsa", "ALSA Sequencer not found, skipping test")
     @unittest.skipIf(not os.path.exists("/dev/snd/seq"), "/dev/snd/seq is not available, skipping test")
     def test_loopback_sequencer(self):


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There are other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

Another issue that must be fixed:  Undefined name '__cmp__' on ./src/events.py line 53