### PR TITLE
Fixed print when Linux install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ def configure_platform():
         setup_alsa(ns)
         pass
     else:
-        print "No sequencer available for '%s' platform." % platform
+        print("No sequencer available for '%s' platform." % platform)
     return ns
 
 if __name__ == "__main__":


### PR DESCRIPTION
when I install with:
`
pip install python-midi
`
I got 

huangzhongyi@ubuntu:~/workspace/python-midi$ pip install python-midi
Collecting python-midi
  Using cached https://files.pythonhosted.org/packages/8d/e1/fd34aa05508d907449fb2d66a679d4f98eeeacdb4b3c7e6af87d91c4fa21/python-midi-v0.2.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-rcr0nu5q/python-midi/setup.py", line 42
        print "No sequencer available for '%s' platform." % platform
                                                        ^
    SyntaxError: Missing parentheses in call to 'print'. Did you mean print(print "No sequencer available for '%s' platform." % platform)?
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-rcr0nu5q/python-midi/

I found there maybe some question in print function of setup.py, I fixed it and successfully installed.