### PR TITLE
Add simple CI on Windows with AppVeyor

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1,4 +1,5 @@
-<a href="https://travis-ci.org/vishnubob/python-midi"><img src="https://travis-ci.org/vishnubob/python-midi.svg?branch=master" alt='Build Statis' /></a>
+<a href="https://travis-ci.org/vishnubob/python-midi"><img src="https://travis-ci.org/vishnubob/python-midi.svg?branch=master" alt='Build Status' /></a> 
+<a href="https://ci.appveyor.com/project/cschied/q2vkpt"><img src="https://ci.appveyor.com/api/projects/status/github/cschied/q2vkpt?branch=master&svg=true" alt='Build Status' /></a>
 <a href='https://coveralls.io/github/vishnubob/python-midi?branch=master'><img src='https://coveralls.io/repos/vishnubob/python-midi/badge.svg?branch=master&service=github' alt='Coverage Status' /></a>
 
 =Python MIDI=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,4 +14,4 @@ build_script:
 
 test_script:
   - mididump.py mary.mid
-  - nosetests --with-coverage --cover-package=midi
+  - midiplay.py 128 0 mary.mid

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,4 +14,3 @@ build_script:
 
 test_script:
   - mididump.py mary.mid
-  - midiplay.py 128 0 mary.mid

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
+
+install:
+  - "%PYTHON%\\python.exe -m pip install wheel"
+
+build_script:
+  - python setup.py install
+
+test_script:
+  - mididump.py mary.mid
+  - nosetests --with-coverage --cover-package=midi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
 install:
   - "%PYTHON%\\python.exe -m pip install wheel"
 
+build: false
+
 build_script:
   - python setup.py install
 


### PR DESCRIPTION
Adds continuous integration on Windows with AppVeyor using Python 2.7, 3.6 and 3.7.

AppVeyor can be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.